### PR TITLE
feat: editable content part 2

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -1,12 +1,24 @@
 use ratatui::{
     layout::Rect,
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, ListState, Paragraph},
     Frame,
 };
+use std::collections::HashMap;
+
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub enum TopicListItem {
+    Tutorials,
+    Guides,
+    Explanation,
+    Reference,
+}
 
 pub struct Content {
     pub content_input: String,
+    topic_content_map: HashMap<TopicListItem, String>,
+    pub enable_insert_mode: bool,
 }
+
 impl Default for Content {
     fn default() -> Self {
         Self::new()
@@ -15,16 +27,74 @@ impl Default for Content {
 
 impl Content {
     pub fn new() -> Self {
+        let mut topic_content_map = HashMap::new();
+        topic_content_map.insert(
+            TopicListItem::Tutorials,
+            "Placeholder content for Tutorials".to_string(),
+        );
+        topic_content_map.insert(
+            TopicListItem::Guides,
+            "Placeholder content for Guides".to_string(),
+        );
+        topic_content_map.insert(
+            TopicListItem::Explanation,
+            "Placeholder content for Explanation".to_string(),
+        );
+        topic_content_map.insert(
+            TopicListItem::Reference,
+            "Placeholder content for Reference".to_string(),
+        );
+
         Self {
             content_input: String::new(),
+            topic_content_map,
+            enable_insert_mode: false,
         }
     }
-    pub fn enable_editing(&mut self, frame: &mut Frame, area: Rect) {
-        let content = Paragraph::new(self.content_input.as_str()).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title("Press ESC to exit editor mode."),
-        );
-        frame.render_widget(content, area);
+ // refactor should be handled by render
+    pub fn select_topic(&mut self, index: usize) {
+        let selected_topic = match index {
+            0 => TopicListItem::Tutorials,
+            1 => TopicListItem::Guides,
+            2 => TopicListItem::Explanation,
+            3 => TopicListItem::Reference,
+            _ => return,
+        };
+
+        if let Some(content) = self.topic_content_map.get(&selected_topic) {
+            self.content_input = content.clone();
+        }
+    }
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, list_state: &ListState) {
+        if self.enable_insert_mode && self.content_input.is_empty() { // because of 2nd condition after deleting last letter input resets - need something better
+            if let Some(selected_index) = list_state.selected() {
+                let selected_topic = match selected_index {
+                    0 => TopicListItem::Tutorials,
+                    1 => TopicListItem::Guides,
+                    2 => TopicListItem::Explanation,
+                    3 => TopicListItem::Reference,
+                    _ => return,
+                };
+
+                if let Some(content) = self.topic_content_map.get(&selected_topic) {
+                    self.content_input = content.clone();
+                }
+            }
+        }
+
+        let title = if self.enable_insert_mode {
+            "Press ESC to exit editor mode."
+        } else {
+            "Press I to enter editing mode"
+        };
+
+        let content_paragraph = Paragraph::new(self.content_input.as_str())
+            .block(Block::default().borders(Borders::ALL).title(title));
+
+        frame.render_widget(content_paragraph, area);
+    }
+
+    pub fn toggle_insert(&mut self) {
+        self.enable_insert_mode = !self.enable_insert_mode
     }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -6,7 +6,7 @@ use ratatui::{
 use std::collections::HashMap;
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
-pub enum TopicListItem {
+pub enum ContentListItem {
     Tutorials,
     Guides,
     Explanation,
@@ -15,7 +15,7 @@ pub enum TopicListItem {
 
 pub struct Content {
     pub content_input: String,
-    topic_content_map: HashMap<TopicListItem, String>,
+    topic_content_map: HashMap<ContentListItem, String>,
     pub enable_insert_mode: bool,
 }
 
@@ -29,19 +29,19 @@ impl Content {
     pub fn new() -> Self {
         let mut topic_content_map = HashMap::new();
         topic_content_map.insert(
-            TopicListItem::Tutorials,
+            ContentListItem::Tutorials,
             "Placeholder content for Tutorials".to_string(),
         );
         topic_content_map.insert(
-            TopicListItem::Guides,
+            ContentListItem::Guides,
             "Placeholder content for Guides".to_string(),
         );
         topic_content_map.insert(
-            TopicListItem::Explanation,
+            ContentListItem::Explanation,
             "Placeholder content for Explanation".to_string(),
         );
         topic_content_map.insert(
-            TopicListItem::Reference,
+            ContentListItem::Reference,
             "Placeholder content for Reference".to_string(),
         );
 
@@ -51,35 +51,31 @@ impl Content {
             enable_insert_mode: false,
         }
     }
-    // refactor should be handled by render
-    pub fn select_topic(&mut self, index: usize) {
-        let selected_topic = match index {
-            0 => TopicListItem::Tutorials,
-            1 => TopicListItem::Guides,
-            2 => TopicListItem::Explanation,
-            3 => TopicListItem::Reference,
-            _ => return,
-        };
 
-        if let Some(content) = self.topic_content_map.get(&selected_topic) {
-            self.content_input = content.clone();
+    fn get_content_for_index(index: usize) -> Option<ContentListItem> {
+        match index {
+            0 => Some(ContentListItem::Tutorials),
+            1 => Some(ContentListItem::Guides),
+            2 => Some(ContentListItem::Explanation),
+            3 => Some(ContentListItem::Reference),
+            _ => None,
         }
     }
-    pub fn render(&mut self, frame: &mut Frame, area: Rect, list_state: &ListState) {
-        if self.enable_insert_mode && self.content_input.is_empty() {
-            // because of 2nd condition after deleting last letter input resets - need something better
-            if let Some(selected_index) = list_state.selected() {
-                let selected_topic = match selected_index {
-                    0 => TopicListItem::Tutorials,
-                    1 => TopicListItem::Guides,
-                    2 => TopicListItem::Explanation,
-                    3 => TopicListItem::Reference,
-                    _ => return,
-                };
 
-                if let Some(content) = self.topic_content_map.get(&selected_topic) {
+    pub fn select_placeholder(&mut self, index: usize) {
+        if let Some(selected_topic) = Content::get_content_for_index(index) {
+            if let Some(content) = self.topic_content_map.get(&selected_topic) {
+                if !self.enable_insert_mode {
                     self.content_input = content.clone();
                 }
+            }
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, list_state: &ListState) {
+        if !self.enable_insert_mode {
+            if let Some(selected_index) = list_state.selected() {
+                self.select_placeholder(selected_index);
             }
         }
 
@@ -96,6 +92,6 @@ impl Content {
     }
 
     pub fn toggle_insert(&mut self) {
-        self.enable_insert_mode = !self.enable_insert_mode
+        self.enable_insert_mode = !self.enable_insert_mode;
     }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -51,7 +51,7 @@ impl Content {
             enable_insert_mode: false,
         }
     }
- // refactor should be handled by render
+    // refactor should be handled by render
     pub fn select_topic(&mut self, index: usize) {
         let selected_topic = match index {
             0 => TopicListItem::Tutorials,
@@ -66,7 +66,8 @@ impl Content {
         }
     }
     pub fn render(&mut self, frame: &mut Frame, area: Rect, list_state: &ListState) {
-        if self.enable_insert_mode && self.content_input.is_empty() { // because of 2nd condition after deleting last letter input resets - need something better
+        if self.enable_insert_mode && self.content_input.is_empty() {
+            // because of 2nd condition after deleting last letter input resets - need something better
             if let Some(selected_index) = list_state.selected() {
                 let selected_topic = match selected_index {
                     0 => TopicListItem::Tutorials,

--- a/src/events.rs
+++ b/src/events.rs
@@ -33,7 +33,7 @@ impl EventHandler {
     pub fn listen_for_keyboard_events(&mut self) -> io::Result<()> {
         if event::poll(Duration::from_millis(250))? {
             if let event::Event::Key(key) = event::read()? {
-                if self.screen.borrow().enable_insert_mode {
+                if self.content.borrow().enable_insert_mode {
                     self.handle_content_input(key)?;
                 } else {
                     self.handle_navigation_input(key)?;
@@ -51,7 +51,7 @@ impl EventHandler {
             KeyCode::Char('s') => {
                 self.save_to_file()?;
             }
-            KeyCode::Char('i') => self.screen.borrow_mut().enable_insert(),
+            KeyCode::Char('i') => self.content.borrow_mut().toggle_insert(),
             KeyCode::Esc => {
                 self.screen.borrow_mut().toggle_popup();
             }
@@ -73,8 +73,14 @@ impl EventHandler {
                     self.should_quit = true;
                 }
             },
-            KeyCode::Down => self.screen.borrow_mut().next(),
-            KeyCode::Up => self.screen.borrow_mut().previous(),
+            KeyCode::Down => self
+                .screen
+                .borrow_mut()
+                .next(&mut self.content.borrow_mut()),
+            KeyCode::Up => self
+                .screen
+                .borrow_mut()
+                .previous(&mut self.content.borrow_mut()),
             _ => {}
         }
         Ok(())
@@ -92,7 +98,7 @@ impl EventHandler {
                 self.content.borrow_mut().content_input.push('\n');
             }
             KeyCode::Esc => {
-                self.screen.borrow_mut().enable_insert();
+                self.content.borrow_mut().toggle_insert();
             }
             _ => {}
         }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -79,12 +79,10 @@ impl Screen {
         if self.show_popup {
             popup.show_popup(frame, area);
         }
-        if self.enable_insert_mode {
-            content.enable_editing(frame, content_area);
-        }
+        content.render(frame, content_area, &self.list_state);
     }
 
-    pub fn next(&mut self) {
+    pub fn next(&mut self, content: &mut Content) {
         let i = match self.list_state.selected() {
             Some(i) => {
                 if i >= self.items.len() - 1 {
@@ -96,8 +94,9 @@ impl Screen {
             None => 0,
         };
         self.list_state.select(Some(i));
+        content.select_topic(i)
     }
-    pub fn previous(&mut self) {
+    pub fn previous(&mut self, content: &mut Content) {
         let i = match self.list_state.selected() {
             Some(i) => {
                 if i == 0 {
@@ -109,17 +108,17 @@ impl Screen {
             None => 0,
         };
         self.list_state.select(Some(i));
+        content.select_topic(i)
     }
     pub fn toggle_popup(&mut self) {
         self.show_popup = !self.show_popup;
-    }
-    pub fn enable_insert(&mut self) {
-        self.enable_insert_mode = !self.enable_insert_mode;
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::content::Content;
+
     use super::Screen;
 
     #[test]
@@ -131,31 +130,33 @@ mod tests {
     #[test]
     fn test_next_navigation() {
         let mut screen = Screen::new();
+        let mut content = Content::new();
         assert_eq!(screen.list_state.selected(), Some(0));
 
-        screen.next();
+        screen.next(&mut content);
         assert_eq!(screen.list_state.selected(), Some(1));
 
-        screen.next();
+        screen.next(&mut content);
         assert_eq!(screen.list_state.selected(), Some(2));
 
-        screen.next();
+        screen.next(&mut content);
         assert_eq!(screen.list_state.selected(), Some(3));
 
-        screen.next();
+        screen.next(&mut content);
         assert_eq!(screen.list_state.selected(), Some(0));
     }
 
     #[test]
     fn test_previous_navigation() {
         let mut screen = Screen::new();
+        let mut content = Content::new();
 
         assert_eq!(screen.list_state.selected(), Some(0));
 
-        screen.previous();
+        screen.previous(&mut content);
         assert_eq!(screen.list_state.selected(), Some(screen.items.len() - 1));
 
-        screen.previous();
+        screen.previous(&mut content);
         assert_eq!(screen.list_state.selected(), Some(screen.items.len() - 2));
     }
 
@@ -185,7 +186,8 @@ mod tests {
     #[test]
     fn test_selection_persistence_after_toggle_popup() {
         let mut screen = Screen::new();
-        screen.next();
+        let mut content = Content::new();
+        screen.next(&mut content);
         assert_eq!(screen.list_state.selected(), Some(1));
 
         screen.toggle_popup();

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -94,7 +94,7 @@ impl Screen {
             None => 0,
         };
         self.list_state.select(Some(i));
-        content.select_topic(i)
+        content.select_placeholder(i)
     }
     pub fn previous(&mut self, content: &mut Content) {
         let i = match self.list_state.selected() {
@@ -108,7 +108,7 @@ impl Screen {
             None => 0,
         };
         self.list_state.select(Some(i));
-        content.select_topic(i)
+        content.select_placeholder(i)
     }
     pub fn toggle_popup(&mut self) {
         self.show_popup = !self.show_popup;


### PR DESCRIPTION
- changes placeholder text as navigation happens
- sets content input as placeholder text when editing is enabled
- fixing enum for domain DSL